### PR TITLE
Do not use GTsoft for single-match VPR as it was not correctly implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ python3 demo.py
 |:-------------------------:|:-------------------------:|:-------------------------:|
 |<img src="output_images/pr_curve.jpg" alt="precision-recall curve P=f(R)" height="200" width="315">  |  <img src="output_images/matchings.jpg" alt="output_images/matchings.jpg" height="200" width="401"> | <img src="output_images/examples_tp_fp.jpg" alt="Examples for true positive (TP) and false positive (FP)" height="200" width="315">| 
 
-
 ## Requirements
 The code was tested with the library versions listed in [requirements.txt](./requirements.txt). Note that Tensorflow or PyTorch is only required if the corresponding image descriptor is used. If you use pip, simply:
 ```bash
@@ -255,3 +254,6 @@ mamba create -n vprtutorial python numpy pytorch torchvision natsort tqdm opencv
 </table>
 
 *Third party code. Not provided by the authors. Code implements the author's idea or can be used to implement the authors idea.
+
+## Soft Ground Truth for evaluation
+In the evaluation metrics, a soft ground truth matrix can be used to ignore images with a very small visual overlap to avoid penalization in recall and precision analysis (see Equation 6 in [our paper](https://ieeexplore.ieee.org/document/10261441)). This may have the consequence of reducing your overall precision and recall accuracy by eliminating potential matches from the evaluation. Please check whether using the soft ground truth is appropriate for your analysis requirements.

--- a/README.md
+++ b/README.md
@@ -256,4 +256,4 @@ mamba create -n vprtutorial python numpy pytorch torchvision natsort tqdm opencv
 *Third party code. Not provided by the authors. Code implements the author's idea or can be used to implement the authors idea.
 
 ## Soft Ground Truth for evaluation
-In the evaluation metrics, a soft ground truth matrix can be used to ignore images with a very small visual overlap to avoid penalization in recall and precision analysis (see Equation 6 in [our paper](https://ieeexplore.ieee.org/document/10261441)). This may have the consequence of reducing your overall precision and recall accuracy by eliminating potential matches from the evaluation. Please check whether using the soft ground truth is appropriate for your analysis requirements.
+In the evaluation metrics, a soft ground truth matrix can be used to ignore images with a very small visual overlap to avoid penalization in recall and precision analysis (see Equation 6 in [our paper](https://ieeexplore.ieee.org/document/10261441)). This currently is only supported for `matching="multi"`. For use in single matching, please use a dilated hard ground truth directly.

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -139,37 +139,26 @@ def recallAt100precision(S_in, GThard, GTsoft=None, matching='multi', n_thresh=1
     return R
 
 
-def recallAtK(S_in, GThard, GTsoft=None, K=1):
+def recallAtK(S, GT, K=1):
     """
-    Calculates the recall@K for a given similarity matrix S_in and ground truth matrices 
-    GThard and GTsoft.
+    Calculates the recall@K for a given similarity matrix S and ground truth matrix GT.
+    Note that this method does not support GTsoft - instead, please directly provide
+    the dilated ground truth matrix as GT.
 
-    The matrices S_in, GThard and GTsoft are two-dimensional and should all have the
-    same shape.
-    The matrices GThard and GTsoft should be binary matrices, where the entries are
-    only zeros or ones.
-    The matrix S_in should have continuous values between -Inf and Inf. Higher values
+    The matrices S and GT are two-dimensional and should all have the same shape.
+    The matrix GT should be binary, where the entries are only zeros or ones.
+    The matrix S should have continuous values between -Inf and Inf. Higher values
     indicate higher similarity.
     The integer K>=1 defines the number of matching candidates that are selected and
     that must contain an actually matching image pair.
     """
 
-    assert (S_in.shape == GThard.shape),"S_in and GThard must have the same shape"
-    if GTsoft is not None:
-        assert (S_in.shape == GTsoft.shape),"S_in and GTsoft must have the same shape"
-    assert (S_in.ndim == 2),"S_in, GThard and GTsoft must be two-dimensional"
+    assert (S.shape == GT.shape),"S and GT must have the same shape"
+    assert (S.ndim == 2),"S and GT must be two-dimensional"
     assert (K >= 1),"K must be >=1"
 
-    if GTsoft is not None:
-        print("===== WARNING GTSoft is being used, which may affect evaluation results. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
-
-    # ensure logical datatype in GT and GTsoft
-    GT = GThard.astype('bool')
-    GTsoft = GTsoft.astype('bool')
-
-    # copy S and set elements that are only true in GTsoft to min(S) to ignore them during evaluation
-    S = S_in.copy()
-    S[GTsoft & ~GT] = S.min()
+    # ensure logical datatype in GT
+    GT = GT.astype('bool')
 
     # discard all query images without an actually matching database image
     j = GT.sum(0) > 0 # columns with matches

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -114,7 +114,7 @@ def recallAt100precision(S_in, GThard, GTsoft=None, matching='multi', n_thresh=1
     assert (matching in ['single', 'multi']),"matching should contain one of the following strings: [single, multi]"
     assert (n_thresh > 1),"n_thresh must be >1"
 
-    if GTsoft is not None:
+    if GTsoft is not None and matching == 'single':
         print("===== WARNING GTSoft is being used, which may affect evaluation results. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
 
     # get precision-recall curve

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -40,8 +40,8 @@ def createPR(S_in, GThard, GTsoft=None, matching='multi', n_thresh=100):
     assert (matching in ['single', 'multi']),"matching should contain one of the following strings: [single, multi]"
     assert (n_thresh > 1),"n_thresh must be >1"
 
-    if GTsoft is not None:
-       print("===== WARNING GTSoft is being used, which may affect evaluation results. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
+    if GTsoft is not None and matching == 'single':
+       print("===== WARNING GTSoft is being used, which was mainly intended for multi-matching VPR. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
 
     # ensure logical datatype in GT and GTsoft
     GT = GThard.astype('bool')

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -40,6 +40,9 @@ def createPR(S_in, GThard, GTsoft=None, matching='multi', n_thresh=100):
     assert (matching in ['single', 'multi']),"matching should contain one of the following strings: [single, multi]"
     assert (n_thresh > 1),"n_thresh must be >1"
 
+    if GTsoft is not None:
+       print("===== WARNING GTSoft is being used, which may affect evaluation results. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
+
     # ensure logical datatype in GT and GTsoft
     GT = GThard.astype('bool')
     if GTsoft is not None:
@@ -111,6 +114,9 @@ def recallAt100precision(S_in, GThard, GTsoft=None, matching='multi', n_thresh=1
     assert (matching in ['single', 'multi']),"matching should contain one of the following strings: [single, multi]"
     assert (n_thresh > 1),"n_thresh must be >1"
 
+    if GTsoft is not None:
+        print("===== WARNING GTSoft is being used, which may affect evaluation results. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
+
     # get precision-recall curve
     P, R = createPR(S_in, GThard, GTsoft, matching=matching, n_thresh=n_thresh)
     P = np.array(P)
@@ -145,6 +151,9 @@ def recallAtK(S_in, GThard, GTsoft=None, K=1):
         assert (S_in.shape == GTsoft.shape),"S_in and GTsoft must have the same shape"
     assert (S_in.ndim == 2),"S_in, GThard and GTsoft must be two-dimensional"
     assert (K >= 1),"K must be >=1"
+
+    if GTsoft is not None:
+        print("===== WARNING GTSoft is being used, which may affect evaluation results. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
 
     # ensure logical datatype in GT and GTsoft
     GT = GThard.astype('bool')

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -41,7 +41,11 @@ def createPR(S_in, GThard, GTsoft=None, matching='multi', n_thresh=100):
     assert (n_thresh > 1),"n_thresh must be >1"
 
     if GTsoft is not None and matching == 'single':
-       print("===== WARNING GTSoft is being used, which was mainly intended for multi-matching VPR. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
+        raise ValueError(
+            "GTSoft with single matching is not supported. "
+            "Please use dilated hard ground truth directly. "
+            "For more details, visit: https://github.com/stschubert/VPR_Tutorial"
+        )
 
     # ensure logical datatype in GT and GTsoft
     GT = GThard.astype('bool')
@@ -115,7 +119,11 @@ def recallAt100precision(S_in, GThard, GTsoft=None, matching='multi', n_thresh=1
     assert (n_thresh > 1),"n_thresh must be >1"
 
     if GTsoft is not None and matching == 'single':
-        print("===== WARNING GTSoft is being used, which may affect evaluation results. Please see https://github.com/stschubert/VPR_Tutorial for more details.")
+        raise ValueError(
+            "GTSoft with single matching is not supported. "
+            "Please use dilated hard ground truth directly. "
+            "For more details, visit: https://github.com/stschubert/VPR_Tutorial"
+        )
 
     # get precision-recall curve
     P, R = createPR(S_in, GThard, GTsoft, matching=matching, n_thresh=n_thresh)


### PR DESCRIPTION
In ./evaluation/metrics.py, provide a printed `WARNING` if using the `GTsoft` in any of the recall, precision, or PR calculations that this may affect your overall performance/accuracy. The details of `GTsoft` has been added to the end of the README to provide more context and to warn users about its potential effects.